### PR TITLE
Add new signing key for Linus

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -101,7 +101,7 @@
 				mirrors = {'http://1.updates.services.luebeck.freifunk.net/stable/sysupgrade'},
 				good_signatures = 2,
 				pubkeys = {
-					'daa19b44bbd7033965e02088127bad9516ba0fea8f34267a777144a23ec8900c', -- Linus
+					'721584567a1a66b6db696b650db802cbdbad5f41456b105ad3f937a71fc28906', -- Linus
 					'323bd3285c4e5547a89cd6da1f2aef67f1654b0928bbd5b104efc9dab2156d0b', -- NeoRaider
 					'fb1790fb4500f0cb94d3bc5b32c28651c83c6415b846d69699cdaeea3385a618', -- Kaspar
 				},
@@ -111,7 +111,7 @@
 				mirrors = {'http://1.updates.services.luebeck.freifunk.net/beta/sysupgrade'},
 				good_signatures = 2,
 				pubkeys = {
-					'daa19b44bbd7033965e02088127bad9516ba0fea8f34267a777144a23ec8900c', -- Linus
+					'721584567a1a66b6db696b650db802cbdbad5f41456b105ad3f937a71fc28906', -- Linus
 					'323bd3285c4e5547a89cd6da1f2aef67f1654b0928bbd5b104efc9dab2156d0b', -- NeoRaider
 					'fb1790fb4500f0cb94d3bc5b32c28651c83c6415b846d69699cdaeea3385a618', -- Kaspar
 				},


### PR DESCRIPTION
I generated a new key for both FFHL and FFOH for a cleaner separation.
Currently both projects have added the same public key of mine to their
firmware. Which isn't really a good idea.

---

Changes in v2:
* Added key to beta branch, too
* Removed old key: Keeping the old key is a bad idea, too. Otherwise,
  I'd be able to upgrade the network all alone by signing with both my
  old and new key