### PR TITLE
Add global IPv6 prefix via extra_prefixes6

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -12,6 +12,7 @@
 
 	prefix4 = '10.130.0.0/20',
 	prefix6 = 'fdef:ffc0:3dd7::/64',
+	extra_prefixes6 = { '2001:67c:2d50::/48' },
 
 	timezone = 'CET-1CEST,M3.5.0,M10.5.0/3', -- Europe/Berlin
 	ntp_servers = {'1.ntp.services.luebeck.freifunk.net'},


### PR DESCRIPTION
I'm using the (still pending) gluon-alt-esc package [0] here
in Lübeck and for that it'd be nice to have the extra_prefixes6
added.

Another potential user of this value is the
gluon-ebtables-source-filter package. However that one is not
in use in Lübeck by anyone so far as far as I know.

[0]: https://github.com/freifunk-gluon/gluon/pull/1094